### PR TITLE
Add Todo List Tool for AI Assistant

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,8 @@ def initialize_session_state():
     """Initialize session state variables"""
     if 'messages' not in st.session_state:
         st.session_state.messages = []
+    if 'todos' not in st.session_state:
+        st.session_state.todos = []
     if 'browser' not in st.session_state:
         st.session_state.browser = None
     if 'ai_client' not in st.session_state:
@@ -66,7 +68,8 @@ def save_chats_to_local():
         for cid, chat in st.session_state.chats.items():
             serializable_chats[cid] = {
                 'title': chat.get('title', 'Untitled Chat'),
-                'messages': chat.get('messages', [])
+                'messages': chat.get('messages', []),
+                'todos': chat.get('todos', [])
             }
         st.session_state.local_storage.setItem("mbu_chats", json.dumps(serializable_chats))
 
@@ -106,7 +109,8 @@ def setup_chat_menu():
         new_id = str(uuid.uuid4())
         st.session_state.chats[new_id] = {
             'title': 'New Chat',
-            'messages': []
+            'messages': [],
+            'todos': []
         }
         st.session_state.current_chat_id = new_id
         st.session_state.messages = []
@@ -127,6 +131,7 @@ def setup_chat_menu():
         if col_chat.button(chat_title, key=f"btn_{cid}", use_container_width=True):
             st.session_state.current_chat_id = cid
             st.session_state.messages = chat.get('messages', [])
+            st.session_state.todos = chat.get('todos', [])
 
         if col_del.button("🗑️", key=f"del_{cid}"):
             delete_chat_screenshots(cid)
@@ -134,6 +139,7 @@ def setup_chat_menu():
             if st.session_state.current_chat_id == cid:
                 st.session_state.current_chat_id = None
                 st.session_state.messages = []
+                st.session_state.todos = []
             save_chats_to_local()
 
 def setup_configuration_panel(container):
@@ -350,7 +356,7 @@ def execute_automation_step(user_objective):
         save_chats_to_local()
 
         response = st.session_state.ai_client.analyze_and_decide(
-            image_data, user_objective, st.session_state.current_objective, image_format=image_format
+            image_data, user_objective, st.session_state.current_objective, image_format=image_format, todos=st.session_state.todos
         )
         
         # Parse response
@@ -361,6 +367,7 @@ def execute_automation_step(user_objective):
         add_message("assistant", action, "action")
         
         # Execute action
+        import re
         if action.lower().startswith('click('):
             # Extract index from click(INDEX)
             index_str = action.split('(')[1].split(')')[0]
@@ -373,7 +380,6 @@ def execute_automation_step(user_objective):
         
         elif action.lower().startswith('type('):
             # Extract text and element from type("TEXT", into="ELEMENT") or type('TEXT', into='ELEMENT')
-            import re
             # Match both single and double quotes
             match = re.search(r"type\(['\"](.*?)['\"]\s*,\s*into\s*=\s*['\"](.*?)['\"]\)", action)
             if match:
@@ -384,6 +390,49 @@ def execute_automation_step(user_objective):
             else:
                 raise Exception(f"Invalid type action format: {action}")
         
+        elif action.lower().startswith('todo_add('):
+            match = re.search(r"todo_add\(['\"](.*?)['\"]\)", action)
+            if match:
+                task = match.group(1)
+                st.session_state.todos.append(task)
+                if st.session_state.current_chat_id:
+                    st.session_state.chats[st.session_state.current_chat_id]['todos'] = st.session_state.todos
+                    save_chats_to_local()
+                add_message("assistant", f"Added to-do: {task}")
+            else:
+                raise Exception(f"Invalid todo_add action format: {action}")
+
+        elif action.lower().startswith('todo_edit('):
+            match = re.search(r"todo_edit\((\d+)\s*,\s*['\"](.*?)['\"]\)", action)
+            if match:
+                idx = int(match.group(1))
+                task = match.group(2)
+                if 0 <= idx < len(st.session_state.todos):
+                    st.session_state.todos[idx] = task
+                    if st.session_state.current_chat_id:
+                        st.session_state.chats[st.session_state.current_chat_id]['todos'] = st.session_state.todos
+                        save_chats_to_local()
+                    add_message("assistant", f"Updated to-do at index {idx}: {task}")
+                else:
+                    raise Exception(f"Todo index {idx} out of range")
+            else:
+                raise Exception(f"Invalid todo_edit action format: {action}")
+
+        elif action.lower().startswith('todo_delete('):
+            match = re.search(r"todo_delete\((\d+)\)", action)
+            if match:
+                idx = int(match.group(1))
+                if 0 <= idx < len(st.session_state.todos):
+                    removed = st.session_state.todos.pop(idx)
+                    if st.session_state.current_chat_id:
+                        st.session_state.chats[st.session_state.current_chat_id]['todos'] = st.session_state.todos
+                        save_chats_to_local()
+                    add_message("assistant", f"Deleted to-do: {removed}")
+                else:
+                    raise Exception(f"Todo index {idx} out of range")
+            else:
+                raise Exception(f"Invalid todo_delete action format: {action}")
+
         elif 'complete' in action.lower() or 'done' in action.lower():
             st.session_state.automation_active = False
             add_message("assistant", "🎉 Objective completed successfully!")
@@ -417,7 +466,9 @@ def main():
             # Set current chat if none selected
             if not st.session_state.current_chat_id and st.session_state.chats:
                 st.session_state.current_chat_id = list(st.session_state.chats.keys())[0]
-                st.session_state.messages = st.session_state.chats[st.session_state.current_chat_id].get('messages', [])
+                current_chat = st.session_state.chats[st.session_state.current_chat_id]
+                st.session_state.messages = current_chat.get('messages', [])
+                st.session_state.todos = current_chat.get('todos', [])
 
     setup_chat_menu()
 
@@ -437,6 +488,12 @@ def main():
         else:
             # Main chat interface
             st.write(f"Objective: **{st.session_state.chats[st.session_state.current_chat_id].get('title')}**")
+
+            # Display Todo List if it exists
+            if st.session_state.todos:
+                with st.expander("📝 Todo List", expanded=True):
+                    for i, todo in enumerate(st.session_state.todos):
+                        st.write(f"{i}. {todo}")
 
             # Display chat history
             display_chat_history()

--- a/fireworks_client.py
+++ b/fireworks_client.py
@@ -10,28 +10,41 @@ class FireworksClient:
         # User requested Kimi K2.6, which maps to kimi-k2p6 in the model list
         self.model = "accounts/fireworks/models/kimi-k2p6"
 
-    def analyze_and_decide(self, image_base64, user_objective, current_context=None, image_format="png"):
+    def analyze_and_decide(self, image_base64, user_objective, current_context=None, image_format="png", todos=None):
         """Analyze screenshot and decide on next action using Fireworks proxy"""
 
-        system_prompt = """You are a web automation assistant powered by computer vision. Your task is to analyze screenshots of web pages and determine the next action to take to achieve the user's objective.
+        todos_str = ""
+        if todos:
+            todos_str = "\n".join([f"{i}. {todo}" for i, todo in enumerate(todos)])
+        else:
+            todos_str = "No todos currently."
+
+        system_prompt = f"""You are a web automation assistant powered by computer vision. Your task is to analyze screenshots of web pages and determine the next action to take to achieve the user's objective.
 
 AVAILABLE ACTIONS:
 - click(INDEX) - Click on an element by its numbered index (shown in red circles)
 - type("TEXT", into="ELEMENT") - Type text into an input field (specify element by description)
+- todo_add("TASK") - Add a new task to your todo list
+- todo_edit(INDEX, "TASK") - Edit an existing task in your todo list
+- todo_delete(INDEX) - Delete a task from your todo list
 - COMPLETE - When the objective is achieved
+
+CURRENT TODO LIST:
+{todos_str}
 
 RESPONSE FORMAT:
 Return a JSON object with exactly these fields:
-{
+{{
     "thinking": "Your reasoning about what you see and what to do next",
-    "action": "The specific action to take (e.g., click(5) or type('hello', into='search box') or COMPLETE)"
-}
+    "action": "The specific action to take (e.g., click(5) or todo_add('Search for flight') or COMPLETE)"
+}}
 
 GUIDELINES:
 - Carefully examine all numbered elements in the image
 - Choose the most logical next step toward the objective
 - Be specific with element indexes when clicking
 - For typing, describe the target element clearly
+- Use the todo list to break down long or complex tasks. DON'T force a todo list at the start, only use it when it helps you stay organized.
 - If the objective appears complete, respond with action: "COMPLETE"
 - Always explain your reasoning in the thinking field"""
 

--- a/mistral_client.py
+++ b/mistral_client.py
@@ -12,29 +12,42 @@ class MistralClient:
         if not self.api_key:
             raise ValueError("Mistral API key is required")
     
-    def analyze_and_decide(self, image_base64, user_objective, current_context=None, image_format="png"):
+    def analyze_and_decide(self, image_base64, user_objective, current_context=None, image_format="png", todos=None):
         """Analyze screenshot and decide on next action"""
         
+        todos_str = ""
+        if todos:
+            todos_str = "\n".join([f"{i}. {todo}" for i, todo in enumerate(todos)])
+        else:
+            todos_str = "No todos currently."
+
         # Construct the prompt for analysis
-        system_prompt = """You are a web automation assistant powered by computer vision. Your task is to analyze screenshots of web pages and determine the next action to take to achieve the user's objective.
+        system_prompt = f"""You are a web automation assistant powered by computer vision. Your task is to analyze screenshots of web pages and determine the next action to take to achieve the user's objective.
 
 AVAILABLE ACTIONS:
 - click(INDEX) - Click on an element by its numbered index (shown in red circles)
 - type("TEXT", into="ELEMENT") - Type text into an input field (specify element by description)
+- todo_add("TASK") - Add a new task to your todo list
+- todo_edit(INDEX, "TASK") - Edit an existing task in your todo list
+- todo_delete(INDEX) - Delete a task from your todo list
 - COMPLETE - When the objective is achieved
+
+CURRENT TODO LIST:
+{todos_str}
 
 RESPONSE FORMAT:
 Return a JSON object with exactly these fields:
-{
+{{
     "thinking": "Your reasoning about what you see and what to do next",
-    "action": "The specific action to take (e.g., click(5) or type('hello', into='search box') or COMPLETE)"
-}
+    "action": "The specific action to take (e.g., click(5) or todo_add('Search for flight') or COMPLETE)"
+}}
 
 GUIDELINES:
 - Carefully examine all numbered elements in the image
 - Choose the most logical next step toward the objective
 - Be specific with element indexes when clicking
 - For typing, describe the target element clearly
+- Use the todo list to break down long or complex tasks. DON'T force a todo list at the start, only use it when it helps you stay organized.
 - If the objective appears complete, respond with action: "COMPLETE"
 - Always explain your reasoning in the thinking field"""
 


### PR DESCRIPTION
This PR introduces a todo list tool for the web automation assistant. 

Key changes:
1. **AI Tools**: Added `todo_add("TASK")`, `todo_edit(INDEX, "TASK")`, and `todo_delete(INDEX)` actions.
2. **AI Instructions**: Updated system prompts to explain how to use the todo list for breaking down complex tasks while avoiding forced initialization.
3. **State Management**: Updated `app.py` to maintain a unique `todos` list for each chat, ensuring it persists in `localStorage`.
4. **UI**: Added a "📝 Todo List" expander in the main chat area that appears when tasks are present.
5. **Automation Loop**: Integrated regex-based parsing and execution of the new todo actions within `execute_automation_step`.